### PR TITLE
Add datadog logger metadata

### DIFF
--- a/lib/teleplug.ex
+++ b/lib/teleplug.ex
@@ -9,12 +9,6 @@ defmodule Teleplug do
   require OpenTelemetry.Tracer, as: Tracer
   require Record
 
-  @span_ctx_fields Record.extract(:span_ctx,
-                     from_lib: "opentelemetry_api/include/opentelemetry.hrl"
-                   )
-
-  Record.defrecord(:span_ctx, @span_ctx_fields)
-
   @behaviour Plug
 
   defdelegate setup, to: Teleplug.Instrumentation
@@ -39,16 +33,14 @@ defmodule Teleplug do
 
     Tracer.set_current_span(new_ctx)
 
-    Logger.metadata(
-      trace_id: span_ctx(new_ctx, :trace_id),
-      span_id: span_ctx(new_ctx, :span_id)
-    )
+    set_logger_metadata(new_ctx)
 
     Conn.register_before_send(conn, fn conn ->
       Tracer.set_attribute("http.status_code", conn.status)
       Tracer.end_span()
 
       Tracer.set_current_span(parent_ctx)
+      set_logger_metadata(parent_ctx)
       conn
     end)
   end
@@ -124,4 +116,28 @@ defmodule Teleplug do
         client
     end
   end
+
+  defp set_logger_metadata(:undefined), do: Logger.metadata(trace_id: nil, span_id: nil, dd: nil)
+
+  defp set_logger_metadata(span_ctx) do
+    trace_id = :otel_span.trace_id(span_ctx)
+    span_id = :otel_span.span_id(span_ctx)
+
+    Logger.metadata(
+      trace_id: trace_id,
+      span_id: span_id,
+      dd: [
+        trace_id: datadog_trace_id(trace_id),
+        span_id: datadog_span_id(span_id)
+      ]
+    )
+  end
+
+  # converts trace_id to a datadog understandable format (taking the 2nd half of the 128 bits string)
+  defp datadog_trace_id(trace_id) do
+    <<_::64, datadog_trace_id::64>> = <<trace_id::128>>
+    to_string(datadog_trace_id)
+  end
+
+  defp datadog_span_id(span_id), do: to_string(span_id)
 end


### PR DESCRIPTION
I refactored logger metadata setting copypasting what was implemented in [stonehenge](https://github.com/primait/stonehenge/blob/37720a76aaf50f8afff0b007635323d29d0c4510/apps/metrix/lib/plugs/opentelemetry.ex#L63)
I added a match on `:undefined` for span_ctx to reset logger metadata if parent context was undefined (as it should be for span starting inside a plug...); it might be unneeded but it could be a starting point to implementing it in opentelemetry_absinthe too.
