### PR TITLE
[PLATFORM-995]: Use OTel recommended names for attributes

### DIFF
--- a/lib/teleplug.ex
+++ b/lib/teleplug.ex
@@ -6,8 +6,23 @@ defmodule Teleplug do
   alias Plug.Conn
 
   require Logger
+  require OpenTelemetry.SemanticConventions.Trace, as: Conventions
   require OpenTelemetry.Tracer, as: Tracer
   require Record
+
+  @http_client_ip Atom.to_string(Conventions.http_client_ip())
+  @http_flavor Atom.to_string(Conventions.http_flavor())
+  @http_method Atom.to_string(Conventions.http_method())
+  @http_route Atom.to_string(Conventions.http_route())
+  @http_scheme Atom.to_string(Conventions.http_scheme())
+  @http_status_code Atom.to_string(Conventions.http_status_code())
+  @http_target Atom.to_string(Conventions.http_target())
+  @http_user_agent Atom.to_string(Conventions.http_user_agent())
+
+  @net_host_name Atom.to_string(Conventions.net_host_name())
+  @net_host_port Atom.to_string(Conventions.net_host_port())
+  @net_sock_peer_port Atom.to_string(Conventions.net_sock_peer_port())
+  @net_sock_peer_addr Atom.to_string(Conventions.net_sock_peer_addr())
 
   @behaviour Plug
 
@@ -34,7 +49,7 @@ defmodule Teleplug do
     Tracer.set_current_span(new_ctx)
 
     Conn.register_before_send(conn, fn conn ->
-      Tracer.set_attribute("http.status_code", conn.status)
+      Tracer.set_attribute(@http_status_code, conn.status)
       Tracer.end_span()
 
       Tracer.set_current_span(parent_ctx)
@@ -53,19 +68,18 @@ defmodule Teleplug do
     route = Teleplug.Instrumentation.get_route(conn.request_path)
 
     [
-      {"http.method", method},
-      {"http.route", route},
-      {"http.target", http_target(conn)},
-      {"http.host", header_value(conn, "host")},
-      {"http.scheme", scheme},
-      {"http.flavor", http_flavor(adapter)},
-      {"http.user_agent", header_value(conn, "user-agent")}
+      {@http_method, method},
+      {@http_route, route},
+      {@http_target, http_target(conn)},
+      {@http_scheme, scheme},
+      {@http_flavor, http_flavor(adapter)},
+      {@http_user_agent, header_value(conn, "user-agent")}
     ]
   end
 
   # see https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions
   defp http_server_attributes(conn),
-    do: [{"http.client_ip", client_ip(conn)}]
+    do: [{@http_client_ip, client_ip(conn)}]
 
   # see https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes
   defp network_attributes(
@@ -77,10 +91,10 @@ defmodule Teleplug do
     peer_data = Plug.Conn.get_peer_data(conn)
 
     [
-      {"net.peer.ip", peer_data |> Map.get(:address) |> :inet_parse.ntoa() |> to_string()},
-      {"net.peer.port", Map.get(peer_data, :port)},
-      {"net.host.name", host},
-      {"net.host.port", port}
+      {@net_sock_peer_addr, peer_data |> Map.get(:address) |> :inet_parse.ntoa() |> to_string()},
+      {@net_sock_peer_port, Map.get(peer_data, :port)},
+      {@net_host_name, host},
+      {@net_host_port, port}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule Teleplug.MixProject do
   defp deps do
     [
       {:opentelemetry_api, "~> 1.1"},
+      {:opentelemetry_semantic_conventions, "~> 0.2"},
       {:plug, "~> 1.11"},
       {:telemetry, "~> 0.4 or ~> 1.0.0 or ~> 1.1.0 or ~> 1.2.0"}
     ] ++ dev_deps()


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-995

This PR introduces the usage of the [otel conventions library](https://hexdocs.pm/opentelemetry_semantic_conventions/0.2.0/) to ensure proper conventions are followed.

Moreover the following changes have been applied

- `"http.host"` removed from `http_common_attributes` since it doesn't exist and is covered by `net.host.name`
- `"net.peer.ip"` and `"net.peer.port"` are now `"net.sock.peer.addr"` and `"net.sock.peer.port"` since the former ones were client attributes and not server attributes

HTTP conventions can be found [here](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/)

