### PR TITLE
Bump elixir

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,8 +11,8 @@ jobs:
       - name: Setup Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: '24'
-          elixir-version: '1.13'
+          otp-version: '25'
+          elixir-version: '1.14'
       - name: Checkout
         uses: actions/checkout@v3
       - name: setup hex

--- a/.github/workflows/retire.yml
+++ b/.github/workflows/retire.yml
@@ -34,8 +34,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: '24'
-          elixir-version: '1.13'
+          otp-version: '25'
+          elixir-version: '1.14'
       - run: echo "Attempting to retire version $VERSION"
       - run: mix hex.config api_key "$HEX_AUTH_KEY"
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/prima/elixir:1.12.2-2
+FROM public.ecr.aws/prima/elixir:1.14.2-5
 
 WORKDIR /code
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Teleplug.MixProject do
     [
       app: :teleplug,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
To fix CD: https://github.com/primait/teleplug/actions/runs/12277793031/job/34257995247

```
Generating docs...
** (FunctionClauseError) no function clause matching in Teleplug.Instrumentation.__info__/1    
    
    The following arguments were given to Teleplug.Instrumentation.__info__/1:
    
        # 1
        :struct
    
    (teleplug 2.0.0) Teleplug.Instrumentation.__info__/1
    (ex_doc 0.35.1) lib/ex_doc/language/elixir.ex:417: ExDoc.Language.Elixir.module_type_and_skip/1
    (ex_doc 0.35.1) lib/ex_doc/language/elixir.ex:33: ExDoc.Language.Elixir.module_data/3
    (ex_doc 0.35.1) lib/ex_doc/retriever.ex:85: ExDoc.Retriever.get_module/2
    (ex_doc 0.35.1) lib/ex_doc/retriever.ex:54: anonymous fn/3 in ExDoc.Retriever.docs_from_modules/3
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ex_doc 0.35.1) lib/ex_doc/retriever.ex:23: ExDoc.Retriever.docs_from_dir/2
    (ex_doc 0.35.1) lib/ex_doc.ex:24: ExDoc.generate_docs/3
```